### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This module provides provisioning functionality for IBM&reg; MQ&reg; 8.x+ as req
 ## How it works
 
 Using [PCF](https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.0.1/com.ibm.mq.amqzag.doc/fa11570_.htm)
-commands, a [Topic](http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.pro.doc/q004990_.htm)
-is created for publishing messages. Receiving messages via consumer groups is implemented as [Subscriptions](http://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.pla.doc/q004950_.htm)
-created and subscribed to the Topic, which are then configured to deliver messages to created [Queues](http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.explorer.doc/e_queues.htm)
+commands, a [Topic](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.pro.doc/q004990_.htm)
+is created for publishing messages. Receiving messages via consumer groups is implemented as [Subscriptions](https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.pla.doc/q004950_.htm)
+created and subscribed to the Topic, which are then configured to deliver messages to created [Queues](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.explorer.doc/e_queues.htm)
 (named according to consumer group name) from which the messages are processed.
 
 ### Security constraints

--- a/src/main/java/org/springframework/cloud/stream/binder/jms/ibmmq/IBMMQRequests.java
+++ b/src/main/java/org/springframework/cloud/stream/binder/jms/ibmmq/IBMMQRequests.java
@@ -32,7 +32,7 @@ public class IBMMQRequests {
 
 	/**
 	 * Thread safe (mostly). See
-	 * http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.javadoc.doc/WMQJavaClasses/com/ibm/mq/MQQueueManager.html
+	 * https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.javadoc.doc/WMQJavaClasses/com/ibm/mq/MQQueueManager.html
 	 */
 	private final MQQueueManager queueManager;
 
@@ -65,7 +65,7 @@ public class IBMMQRequests {
 		}
 		catch (MQException e) {
 			// see
-			// http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm
+			// https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm
 			if (e.getReason() != MQ_OBJECT_ALREADY_EXISTS) {
 				throw new RuntimeException(
 						String.format("Could not provision topic '%s'", topicName), e);
@@ -115,7 +115,7 @@ public class IBMMQRequests {
 		}
 		catch (MQException e) {
 			// see
-			// http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm
+			// https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm
 			if (e.getReason() != MQ_OBJECT_ALREADY_EXISTS) {
 				throw new RuntimeException(
 						String.format("Could not create queue '%s'", queueName), e);
@@ -166,7 +166,7 @@ public class IBMMQRequests {
 			}
 			catch (MQException e) {
 				// see
-				// http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm
+				// https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm
 				if (e.getReason() != MQ_SUBSCRIPTION_ALREADY_EXISTS
 						&& e.getReason() != MQ_OBJECT_ALREADY_EXISTS) {
 					throw new RuntimeException(

--- a/src/main/java/org/springframework/cloud/stream/binder/jms/ibmmq/config/IBMMQJmsConfiguration.java
+++ b/src/main/java/org/springframework/cloud/stream/binder/jms/ibmmq/config/IBMMQJmsConfiguration.java
@@ -42,7 +42,7 @@ public class IBMMQJmsConfiguration {
 	@Bean
 	public MQConnectionFactory connectionFactory(
 			IBMMQConfigurationProperties configurationProperties) throws Exception {
-		// see http://stackoverflow.com/a/33135633/2408961
+		// see https://stackoverflow.com/a/33135633/2408961
 		MQEnvironment.hostname = configurationProperties.getHost();
 		MQEnvironment.port = configurationProperties.getPort();
 		MQEnvironment.channel = configurationProperties.getChannel();


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://stackoverflow.com/a/33135633/2408961 with 1 occurrences migrated to:  
  https://stackoverflow.com/a/33135633/2408961 ([https](https://stackoverflow.com/a/33135633/2408961) result 200).
* [ ] http://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.pla.doc/q004950_.htm with 1 occurrences migrated to:  
  https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.pla.doc/q004950_.htm ([https](https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.pla.doc/q004950_.htm) result 200).
* [ ] http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.explorer.doc/e_queues.htm with 1 occurrences migrated to:  
  https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.explorer.doc/e_queues.htm ([https](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.explorer.doc/e_queues.htm) result 200).
* [ ] http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.javadoc.doc/WMQJavaClasses/com/ibm/mq/MQQueueManager.html with 1 occurrences migrated to:  
  https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.javadoc.doc/WMQJavaClasses/com/ibm/mq/MQQueueManager.html ([https](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.javadoc.doc/WMQJavaClasses/com/ibm/mq/MQQueueManager.html) result 200).
* [ ] http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.pro.doc/q004990_.htm with 1 occurrences migrated to:  
  https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.pro.doc/q004990_.htm ([https](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.pro.doc/q004990_.htm) result 200).
* [ ] http://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm with 3 occurrences migrated to:  
  https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm ([https](https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.tro.doc/q048200_.htm) result 200).